### PR TITLE
Update gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is my custom portfolio website made using _HTML_, _CSS_ and _JavaScript_.
 
 The website is deployed to **GitHub Pages** and can be found [here](https://schmelto.github.io/Portfolio/).
 
-[![portfolio](./assets/portfolio.gif)](https://schmelto.github.io/Portfolio/)
+![portfolio](https://user-images.githubusercontent.com/62628408/146424076-d0ca4032-bb2f-44ce-8920-5619f4dee695.gif)
 
 ## Prerequisites
 


### PR DESCRIPTION
Took an updated shot of the portfolio page and added it to the README.

Fixes #138

I can see the gif is added from the assets folder of the page. Will you need it to be changed in that location as well? 
